### PR TITLE
stabilize parallel processing for callMT

### DIFF
--- a/man/callMT.Rd
+++ b/man/callMT.Rd
@@ -5,7 +5,7 @@
 \alias{callMTVars}
 \title{call mitochondrial variants against rCRS from an MAlignments[List] object}
 \usage{
-callMT(mal, ..., parallel = FALSE, verbose = FALSE)
+callMT(mal, ..., parallel = FALSE, cores = 1, verbose = FALSE)
 
 callMTVars(BAM, SIZE = 75, GENOME = "rCRS", CHR = "chrM",
   COV = NULL, verbose = FALSE)
@@ -16,6 +16,8 @@ callMTVars(BAM, SIZE = 75, GENOME = "rCRS", CHR = "chrM",
 \item{...}{other arguments to pass to VariantTools::callVariants}
 
 \item{parallel}{try to run in parallel? (FALSE; this is super unstable)}
+
+\item{cores}{the number of cores to use for parallel processing}
 
 \item{verbose}{be verbose? (FALSE; turn on for debugging purposes)}
 


### PR DESCRIPTION
This has the added bonus of making low coverage samples run without blowing up. The tallyVariants function uses the bplapply function as a parallel processing backend with the intended purpose of parallelizing over each chromosome. The drawback here is that sometimes with low coverage samples, a worker is handed an empty object and blows up. Patched this by explicitly setting the backend workers to 1 (for chrM) and that in turn stabilizes multicore processing in callMT. You can now set the number of cores to use too.